### PR TITLE
Remove .main-panel in main.js to fix the issue with xkcd panel loading

### DIFF
--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -11,7 +11,7 @@ function initXKCD() {
 	xkcd.id = "xkcdfield";
 	para.appendChild(xkcd);
 
-	var x = jQuery(".main-panel .content").prepend(para);
+	var x = jQuery(".content").prepend(para);
 
 	if(rundeckPage.path() === "menu/projectHome"){
 		//on any project page


### PR DESCRIPTION
The CSS class .main-panel has been removed in the latest version, leading to the plugin successfully importing but failing to show the xkcd panel. 

Hence, removed the class and tested the changes in Rundeck 5.5.x