### PR TITLE
Pick up user's date during make build to make it easier for user to build the plugin

### DIFF
--- a/getSources.sh
+++ b/getSources.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-TODAY=2177
+TODAY=$(date +%Y) # Pick up the user's year automatically
 START=$TODAY-365
 echo "{ \"list\": ["
  


### PR DESCRIPTION
Replaced the hardcoded year with a system date picker so that the user can easily build the plugin without additional steps